### PR TITLE
Bring globbing support!

### DIFF
--- a/src/RefasmerExe/RefasmerExe.csproj
+++ b/src/RefasmerExe/RefasmerExe.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
       <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This is mostly useful for properly structuring output — just passing a proper list of files is not enough for that, you have to let the tool know how to place output files relatively to each other.
Also when aborting on first error with multiple files tell about that explicitly.