### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Can be used as library (Refasmer.dll).
 You could download refasmer from GitHub: https://github.com/JetBrains/Refasmer/releases or install as .NET Tool:
 ```dotnet tool install -g JetBrains.Refasmer.CliTool```
 
+### NuGet packages
+
+| Package                        | Version                                                             |
+|--------------------------------|---------------------------------------------------------------------|
+| **JetBrains.Refasmer**         | ![Nuget](https://img.shields.io/nuget/v/JetBrains.Refasmer)         |
+| **JetBrains.Refasmer.CliTool** | ![Nuget](https://img.shields.io/nuget/v/JetBrains.Refasmer.CliTool) |
+
 ## Usage:
 ```
 refasmer [options] <dll> [<dll> ...]

--- a/src/.idea/.idea.Refasmer/.idea/dictionaries/fried.xml
+++ b/src/.idea/.idea.Refasmer/.idea/dictionaries/fried.xml
@@ -1,0 +1,7 @@
+﻿<component name="ProjectDictionaryState">
+  <dictionary name="fried">
+    <words>
+      <w>refasmer</w>
+    </words>
+  </dictionary>
+</component>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,15 @@
+﻿<Project>
+    <PropertyGroup Label="Packaging">
+        <PackageVersion>1.0$(VERSION_POSTFIX)</PackageVersion>
+        <Copyright>Copyright © JetBrains 2023</Copyright>
+
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <Authors>JetBrains</Authors>
+        <Description>JetBrains :: Refasmer — strip assembly to public API</Description>
+        <PackageProjectUrl>https://github.com/JetBrains/Refasmer</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/JetBrains/Refasmer</RepositoryUrl>
+        <PackageLicense>https://github.com/JetBrains/Refasmer/blob/HEAD/LICENSE</PackageLicense>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
+</Project>

--- a/src/Refasmer/Refasmer.csproj
+++ b/src/Refasmer/Refasmer.csproj
@@ -11,17 +11,7 @@
     </PropertyGroup>
     <PropertyGroup>
         <PackageId>JetBrains.Refasmer</PackageId>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <Title>Refasmer</Title>
-        <Authors>JetBrains</Authors>
-        <Description>JetBrains :: Refasmer — strip assembly to public API</Description>
-        <Copyright>Copyright © JetBrains 2020</Copyright>
-        <PackageProjectUrl>https://github.com/JetBrains/Refasmer</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/JetBrains/Refasmer</RepositoryUrl>
-        <PackageVersion>1.0$(VERSION_POSTFIX)</PackageVersion>
-        <PackageLicense>https://github.com/JetBrains/Refasmer/blob/master/LICENSE</PackageLicense>
-        <PackageIcon>icon.png</PackageIcon>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.10.0" />

--- a/src/Refasmer/Refasmer.csproj
+++ b/src/Refasmer/Refasmer.csproj
@@ -21,10 +21,12 @@
         <PackageVersion>1.0$(VERSION_POSTFIX)</PackageVersion>
         <PackageLicense>https://github.com/JetBrains/Refasmer/blob/master/LICENSE</PackageLicense>
         <PackageIcon>icon.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.10.0" />
         <PackageReference Include="System.Reflection.Metadata" Version="1.7.0" />
         <None Include="icon.png" Pack="true" PackagePath="icon.png" />
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 </Project>

--- a/src/Refasmer/Utils/PublicKeyTokenCalculator.cs
+++ b/src/Refasmer/Utils/PublicKeyTokenCalculator.cs
@@ -7,7 +7,7 @@ namespace JetBrains.Refasmer
     {
         public static byte[] CalculatePublicKeyToken( byte[] publicKey )
         {
-            var sha1Algo = new SHA1Managed();
+            using var sha1Algo = SHA1.Create();
             var hash = sha1Algo.ComputeHash(publicKey);
             
             var publicKeyToken = new byte [8];

--- a/src/RefasmerCliTool/RefasmerCliTool.csproj
+++ b/src/RefasmerCliTool/RefasmerCliTool.csproj
@@ -22,11 +22,13 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/JetBrains/Refasmer</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\RefasmerExe\RefasmerExe.csproj" />
-      <None Include="..\Refasmer\icon.png" Pack="true" PackagePath="" />
+        <ProjectReference Include="..\RefasmerExe\RefasmerExe.csproj"/>
+        <None Include="..\Refasmer\icon.png" Pack="true" PackagePath=""/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
 
 </Project>

--- a/src/RefasmerCliTool/RefasmerCliTool.csproj
+++ b/src/RefasmerCliTool/RefasmerCliTool.csproj
@@ -12,17 +12,7 @@
         <IsPackable>true</IsPackable>
         <ToolCommandName>refasmer</ToolCommandName>
         <Title>RefasmerCliTool</Title>
-        <Description>JetBrains :: Refasmer — strip assembly to public API</Description>
-        <Copyright>Copyright © JetBrains 2020</Copyright>
-        <Authors>JetBrains</Authors>
         <PackAsTool>true</PackAsTool>
-        <PackageVersion>1.0$(VERSION_POSTFIX)</PackageVersion>
-        <PackageLicense>https://github.com/JetBrains/Refasmer/blob/master/LICENSE</PackageLicense>
-        <RepositoryUrl>https://github.com/JetBrains/Refasmer</RepositoryUrl>
-        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <PackageProjectUrl>https://github.com/JetBrains/Refasmer</PackageProjectUrl>
-        <PackageIcon>icon.png</PackageIcon>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Add NuGet package links to the README file
- Add the README file into the packages themselves
- Clean up the packaging stuff in the `.csproj` files
- Update the copyright year
- Migrate from obsolete `SHA1Managed` crypto provider API