### PR TITLE
Expose internal types in API if they are used in public methods

### DIFF
--- a/src/Refasmer/Importer/Caches.cs
+++ b/src/Refasmer/Importer/Caches.cs
@@ -18,7 +18,7 @@ public partial class MetadataImporter
     private readonly Dictionary<InterfaceImplementationHandle, InterfaceImplementationHandle> _interfaceImplementationCache = new();
     private readonly Dictionary<GenericParameterHandle, GenericParameterHandle> _genericParameterCache = new();
     private readonly Dictionary<GenericParameterConstraintHandle, GenericParameterConstraintHandle> _genericParameterConstraintCache = new(); 
-    private readonly Dictionary<TypeDefinitionHandle, TypeDefinitionHandle> _typeDefinitionCache = new();
+    private Dictionary<TypeDefinitionHandle, TypeDefinitionHandle> _typeDefinitionCache = null!;
     private readonly Dictionary<MethodDefinitionHandle, MethodDefinitionHandle> _methodDefinitionCache = new();
     private readonly Dictionary<FieldDefinitionHandle, FieldDefinitionHandle> _fieldDefinitionCache = new();
     private readonly Dictionary<PropertyDefinitionHandle, PropertyDefinitionHandle> _propertyDefinitionCache = new();

--- a/src/Refasmer/Importer/ISignatureVisitor.cs
+++ b/src/Refasmer/Importer/ISignatureVisitor.cs
@@ -1,0 +1,16 @@
+using System.Reflection.Metadata;
+
+namespace JetBrains.Refasmer.Importer;
+
+internal interface ISignatureVisitor<out T>
+{
+    void VisitReader(BlobReader reader);
+
+    void WriteByte(byte @byte);
+    void WriteCompressedInteger(int integer);
+    void WriteCompressedSignedInteger(int integer);
+
+    void VisitTypeHandle(EntityHandle srcHandle);
+
+    T GetResult();
+}

--- a/src/Refasmer/Importer/ReferenceAssemblyAttr.cs
+++ b/src/Refasmer/Importer/ReferenceAssemblyAttr.cs
@@ -119,7 +119,7 @@ public partial class MetadataImporter
         else
         {
             var attrHandle = _builder.AddCustomAttribute(Import(EntityHandle.AssemblyDefinition), ctorHandle, _builder.GetOrAddBlob(VoidValueBlob));
-            Debug?.Invoke($"Added ReferenceAssembly attribute {RowId(attrHandle):X}");
+            Debug?.Invoke($"Added ReferenceAssembly attribute {RowId(attrHandle)}");
         }
     }   
 }

--- a/src/Refasmer/Importer/SimpleImports.cs
+++ b/src/Refasmer/Importer/SimpleImports.cs
@@ -98,7 +98,7 @@ public partial class MetadataImporter
         }
 
         cache.Add(srcHandle, dstHandle);
-        Trace?.Invoke($"Imported {toString(srcHandle)} -> {RowId(dstHandle!):X}");
+        Trace?.Invoke($"Imported {toString(srcHandle)} -> {RowId(dstHandle!)}");
 
         return dstHandle;
     }

--- a/src/Refasmer/ToString/EntityToString.cs
+++ b/src/Refasmer/ToString/EntityToString.cs
@@ -11,69 +11,69 @@ public static class EntityToString
     public static string ToString( this MetadataReader reader, BlobHandle x) => BitConverter.ToString(reader.GetBlobBytes(x)).Replace("-", string.Empty);
 
     public static string ToString( this MetadataReader reader, AssemblyDefinitionHandle _) => reader.ToString(reader.GetAssemblyDefinition());
-    public static string ToString( this MetadataReader reader, AssemblyDefinition x) => $"{{AssemblyDef[{RowId(x):X}]: {reader.ToString(x.Name)} {x.Version}}}";
+    public static string ToString( this MetadataReader reader, AssemblyDefinition x) => $"{{AssemblyDef[{RowId(x)}]: {reader.ToString(x.Name)} {x.Version}}}";
     public static string ToString( this MetadataReader reader, ModuleDefinitionHandle _) => reader.ToString(reader.GetModuleDefinition());
-    public static string ToString( this MetadataReader reader, ModuleDefinition x) => $"{{ModuleDef[{RowId(x):X}]: {reader.ToString(x.Name)} {reader.ToString(x.Mvid)} }}";
+    public static string ToString( this MetadataReader reader, ModuleDefinition x) => $"{{ModuleDef[{RowId(x)}]: {reader.ToString(x.Name)} {reader.ToString(x.Mvid)} }}";
         
     public static string ToString( this MetadataReader reader, AssemblyReferenceHandle x)  => reader.ToString(reader.GetAssemblyReference(x));
-    public static string ToString( this MetadataReader reader, AssemblyReference x) => $"{{AssemblyRef[{RowId(x):X}]: {reader.ToString(x.Name)} {x.Version}}}";
+    public static string ToString( this MetadataReader reader, AssemblyReference x) => $"{{AssemblyRef[{RowId(x)}]: {reader.ToString(x.Name)} {x.Version}}}";
 
     public static string ToString( this MetadataReader reader, ModuleReferenceHandle x)  => reader.ToString(reader.GetModuleReference(x));
-    public static string ToString( this MetadataReader reader, ModuleReference x) => $"{{ModuleRef[{RowId(x):X}]: {reader.ToString(x.Name)}}}";
+    public static string ToString( this MetadataReader reader, ModuleReference x) => $"{{ModuleRef[{RowId(x)}]: {reader.ToString(x.Name)}}}";
         
     public static string ToString( this MetadataReader reader, AssemblyFileHandle x)  => reader.ToString(reader.GetAssemblyFile(x));
-    public static string ToString( this MetadataReader reader, AssemblyFile x) => $"{{AssemblyFile[{RowId(x):X}]: {reader.ToString(x.Name)}}}";
+    public static string ToString( this MetadataReader reader, AssemblyFile x) => $"{{AssemblyFile[{RowId(x)}]: {reader.ToString(x.Name)}}}";
 
     public static string ToString( this MetadataReader reader, TypeReferenceHandle x)  => reader.ToString(reader.GetTypeReference(x));
-    public static string ToString( this MetadataReader reader, TypeReference x) => $"{{TypeRef[{RowId(x):X}]: {reader.ToString(x.Namespace)}::{reader.ToString(x.Name)}}}";
+    public static string ToString( this MetadataReader reader, TypeReference x) => $"{{TypeRef[{RowId(x)}]: {reader.ToString(x.Namespace)}::{reader.ToString(x.Name)}}}";
 
     public static string ToString( this MetadataReader reader, MemberReferenceHandle x)  => reader.ToString(reader.GetMemberReference(x));
-    public static string ToString( this MetadataReader reader, MemberReference x) => $"{{MemberRef[{RowId(x):X}]: {reader.ToString(x.Parent)} {reader.ToString(x.Name)} {reader.SignatureWithHeaderToString(x.Signature)}}}";
+    public static string ToString( this MetadataReader reader, MemberReference x) => $"{{MemberRef[{RowId(x)}]: {reader.ToString(x.Parent)} {reader.ToString(x.Name)} {reader.SignatureWithHeaderToString(x.Signature)}}}";
 
     public static string ToString( this MetadataReader reader, TypeDefinitionHandle x)  => reader.ToString(reader.GetTypeDefinition(x));
-    public static string ToString( this MetadataReader reader, TypeDefinition x) => $"{{TypeDef[{RowId(x):X}]: {reader.ToString(x.Namespace)}::{reader.ToString(x.Name)}}}";
+    public static string ToString( this MetadataReader reader, TypeDefinition x) => $"{{TypeDef[{RowId(x)}]: {reader.ToString(x.Namespace)}::{reader.ToString(x.Name)}}}";
 
     public static string ToString( this MetadataReader reader, TypeSpecificationHandle x)  => reader.ToString(reader.GetTypeSpecification(x));
-    public static string ToString( this MetadataReader reader, TypeSpecification x) => $"{{TypeSpec[{RowId(x):X}]: {reader.TypeSignatureToString(x.Signature)}}}";
+    public static string ToString( this MetadataReader reader, TypeSpecification x) => $"{{TypeSpec[{RowId(x)}]: {reader.TypeSignatureToString(x.Signature)}}}";
         
     public static string ToString( this MetadataReader reader, FieldDefinitionHandle x)  => reader.ToString(reader.GetFieldDefinition(x));
-    public static string ToString( this MetadataReader reader, FieldDefinition x) => $"{{FieldDef[{RowId(x):X}]: {reader.ToString(x.Name)}}}";
+    public static string ToString( this MetadataReader reader, FieldDefinition x) => $"{{FieldDef[{RowId(x)}]: {reader.ToString(x.Name)}}}";
         
     public static string ToString( this MetadataReader reader, MethodDefinitionHandle x)  => reader.ToString(reader.GetMethodDefinition(x));
-    public static string ToString( this MetadataReader reader, MethodDefinition x) => $"{{MethodDef[{RowId(x):X}]: {reader.ToString(x.Name)}}}";
+    public static string ToString( this MetadataReader reader, MethodDefinition x) => $"{{MethodDef[{RowId(x)}]: {reader.ToString(x.Name)}}}";
 
     public static string ToString( this MetadataReader reader, MethodImplementationHandle x)  => reader.ToString(reader.GetMethodImplementation(x));
-    public static string ToString( this MetadataReader reader, MethodImplementation x) => $"{{MethodImpl[{RowId(x):X}]: {reader.ToString(x.MethodBody)} {reader.ToString(x.MethodDeclaration)}}}";
+    public static string ToString( this MetadataReader reader, MethodImplementation x) => $"{{MethodImpl[{RowId(x)}]: {reader.ToString(x.MethodBody)} {reader.ToString(x.MethodDeclaration)}}}";
 
     public static string ToString( this MetadataReader reader, GenericParameterHandle x)  => reader.ToString(reader.GetGenericParameter(x));
-    public static string ToString( this MetadataReader reader, GenericParameter x) => $"{{GenParam[{RowId(x):X}]: {reader.ToString(x.Name)}}}";
+    public static string ToString( this MetadataReader reader, GenericParameter x) => $"{{GenParam[{RowId(x)}]: {reader.ToString(x.Name)}}}";
 
     public static string ToString( this MetadataReader reader, GenericParameterConstraintHandle x)  => reader.ToString(reader.GetGenericParameterConstraint(x));
-    public static string ToString( this MetadataReader reader, GenericParameterConstraint x) => $"{{GenParamConstr[{RowId(x):X}]: {reader.ToString(x.Parameter)} {reader.ToString(x.Type)}}}";
+    public static string ToString( this MetadataReader reader, GenericParameterConstraint x) => $"{{GenParamConstr[{RowId(x)}]: {reader.ToString(x.Parameter)} {reader.ToString(x.Type)}}}";
 
     public static string ToString( this MetadataReader reader, ParameterHandle x)  => reader.ToString(reader.GetParameter(x));
-    public static string ToString( this MetadataReader reader, Parameter x) => $"{{Param[{RowId(x):X}]: {reader.ToString(x.Name)}}}";
+    public static string ToString( this MetadataReader reader, Parameter x) => $"{{Param[{RowId(x)}]: {reader.ToString(x.Name)}}}";
 
     public static string ToString( this MetadataReader reader, InterfaceImplementationHandle x)  => reader.ToString(reader.GetInterfaceImplementation(x));
-    public static string ToString( this MetadataReader reader, InterfaceImplementation x) => $"{{IntImpl[{RowId(x):X}]: {reader.ToString(x.Interface)}}}";
+    public static string ToString( this MetadataReader reader, InterfaceImplementation x) => $"{{IntImpl[{RowId(x)}]: {reader.ToString(x.Interface)}}}";
         
     public static string ToString( this MetadataReader reader, EventDefinitionHandle x)  => reader.ToString(reader.GetEventDefinition(x));
-    public static string ToString( this MetadataReader reader, EventDefinition x) => $"{{EventDef[{RowId(x):X}]: {reader.ToString(x.Name)}}}";
+    public static string ToString( this MetadataReader reader, EventDefinition x) => $"{{EventDef[{RowId(x)}]: {reader.ToString(x.Name)}}}";
 
     public static string ToString( this MetadataReader reader, PropertyDefinitionHandle x)  => reader.ToString(reader.GetPropertyDefinition(x));
-    public static string ToString( this MetadataReader reader, PropertyDefinition x) => $"{{PropertyDef[{RowId(x):X}]: {reader.ToString(x.Name)}}}";
+    public static string ToString( this MetadataReader reader, PropertyDefinition x) => $"{{PropertyDef[{RowId(x)}]: {reader.ToString(x.Name)}}}";
 
     public static string ToString( this MetadataReader reader, ExportedTypeHandle x)  => reader.ToString(reader.GetExportedType(x));
-    public static string ToString( this MetadataReader reader, ExportedType x) => $"{{ExpType[{RowId(x):X}]: {reader.ToString(x.Namespace)}::{reader.ToString(x.Name)} {reader.ToString(x.Implementation)}[{x.GetTypeDefinitionId()}]}}";
+    public static string ToString( this MetadataReader reader, ExportedType x) => $"{{ExpType[{RowId(x)}]: {reader.ToString(x.Namespace)}::{reader.ToString(x.Name)} {reader.ToString(x.Implementation)}[{x.GetTypeDefinitionId()}]}}";
 
     public static string ToString( this MetadataReader reader, CustomAttributeHandle x)  => reader.ToString(reader.GetCustomAttribute(x));
-    public static string ToString( this MetadataReader reader, CustomAttribute x) => $"{{CustomAttr[{RowId(x):X}]: {reader.ToString(reader.GetCustomAttrClass(x))} {reader.ToString(x.Parent)}}}";
+    public static string ToString( this MetadataReader reader, CustomAttribute x) => $"{{CustomAttr[{RowId(x)}]: {reader.ToString(reader.GetCustomAttrClass(x))} {reader.ToString(x.Parent)}}}";
 
     public static string ToString( this MetadataReader reader, DeclarativeSecurityAttributeHandle x)  => reader.ToString(reader.GetDeclarativeSecurityAttribute(x));
-    public static string ToString( this MetadataReader reader, DeclarativeSecurityAttribute x) => $"{{DeclSecAttr[{RowId(x):X}]: {reader.ToString(x.PermissionSet)}}}";
+    public static string ToString( this MetadataReader reader, DeclarativeSecurityAttribute x) => $"{{DeclSecAttr[{RowId(x)}]: {reader.ToString(x.PermissionSet)}}}";
 
     public static string ToString( this MetadataReader reader, ConstantHandle x)  => reader.ToString(reader.GetConstant(x));
-    public static string ToString( this MetadataReader reader, Constant x) => $"{{Const[{RowId(x):X}]: {reader.ToString(x.Parent)}}}";
+    public static string ToString( this MetadataReader reader, Constant x) => $"{{Const[{RowId(x)}]: {reader.ToString(x.Parent)}}}";
 
     public static string ToString( this MetadataReader reader, EntityHandle x)
     {

--- a/tests/Refasmer.Tests/IntegrationTestBase.cs
+++ b/tests/Refasmer.Tests/IntegrationTestBase.cs
@@ -82,7 +82,7 @@ public abstract class IntegrationTestBase : IDisposable
         {
             var type = assembly.MainModule.GetType(typeName);
             Assert.That(
-                assembly.MainModule.GetType(typeName),
+                type,
                 Is.Not.Null,
                 $"Type \"{typeName}\" is not found in assembly \"{assemblyPath}\".");
 

--- a/tests/Refasmer.Tests/IntegrationTestBase.cs
+++ b/tests/Refasmer.Tests/IntegrationTestBase.cs
@@ -49,7 +49,7 @@ public abstract class IntegrationTestBase : IDisposable
     {
         var args = new List<string>
         {
-            "-v",
+            "-vvv",
             $"--output={outputPath}"
         };
         args.AddRange(additionalOptions);

--- a/tests/Refasmer.Tests/IntegrationTests.cs
+++ b/tests/Refasmer.Tests/IntegrationTests.cs
@@ -33,4 +33,14 @@ public class IntegrationTests : IntegrationTestBase
         var resultAssembly = RefasmTestAssembly(assemblyPath, omitNonApiMembers: true);
         await VerifyTypeContent(resultAssembly, typeName);
     }
+
+    [Test]
+    public async Task InternalTypeInPublicApi()
+    {
+        var assemblyPath = await BuildTestAssemblyWithInternalTypeInPublicApi();
+        var resultAssembly = RefasmTestAssembly(assemblyPath, omitNonApiMembers: true);
+        await VerifyTypeContents(
+            resultAssembly,
+            ["RefasmerTestAssembly.PublicClassWithInternalTypeInApi", "RefasmerTestAssembly.ClassToBeMarkedAsInternal"]);
+    }
 }

--- a/tests/Refasmer.Tests/IntegrationTests.cs
+++ b/tests/Refasmer.Tests/IntegrationTests.cs
@@ -41,6 +41,6 @@ public class IntegrationTests : IntegrationTestBase
         var resultAssembly = RefasmTestAssembly(assemblyPath, omitNonApiMembers: true);
         await VerifyTypeContents(
             resultAssembly,
-            ["RefasmerTestAssembly.PublicClassWithInternalTypeInApi", "RefasmerTestAssembly.ClassToBeMarkedAsInternal"]);
+            ["RefasmerTestAssembly.PublicClassWithInternalTypeInApi", "RefasmerTestAssembly.ClassToBeMarkedInternal"]);
     }
 }

--- a/tests/Refasmer.Tests/data/IntegrationTests.InternalTypeInPublicApi.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.InternalTypeInPublicApi.verified.txt
@@ -1,0 +1,5 @@
+﻿public type: RefasmerTestAssembly.PublicClassWithInternalTypeInApi
+methods:
+- Accept(RefasmerTestAssembly.ClassToBeMarkedInternal argument): System.Void:
+- .ctor(): System.Void:
+internal type: RefasmerTestAssembly.ClassToBeMarkedInternal

--- a/tests/RefasmerTestAssembly/PublicClassWithInternalTypeInApi.cs
+++ b/tests/RefasmerTestAssembly/PublicClassWithInternalTypeInApi.cs
@@ -1,0 +1,8 @@
+namespace RefasmerTestAssembly;
+
+public class PublicClassWithInternalTypeInApi
+{
+    public void Accept(ClassToBeMarkedInternal argument) {}
+}
+
+public class ClassToBeMarkedInternal; // post-processed by tests


### PR DESCRIPTION
Such internal types are exposed as stubs only.

Fixes #38.