### PR TITLE
Bugfix/45.value field in enums

### DIFF
--- a/tests/Refasmer.Tests/IntegrationTests.cs
+++ b/tests/Refasmer.Tests/IntegrationTests.cs
@@ -10,6 +10,8 @@ public class IntegrationTests : IntegrationTestBase
     [TestCase("RefasmerTestAssembly.BlittableStructWithPrivateFields")]
     [TestCase("RefasmerTestAssembly.NonBlittableStructWithPrivateFields")]
     [TestCase("RefasmerTestAssembly.NonBlittableGraph")]
+    [TestCase("RefasmerTestAssembly.InternalEnumType")]
+    [TestCase("RefasmerTestAssembly.EnumType")]
     public async Task CheckRefasmedType(string typeName)
     {
         var assemblyPath = await BuildTestAssembly();
@@ -28,6 +30,8 @@ public class IntegrationTests : IntegrationTestBase
     [TestCase("RefasmerTestAssembly.EmptyStructWithStaticMember")]
     [TestCase("RefasmerTestAssembly.NonEmptyStructWithStaticMember")]
     [TestCase("RefasmerTestAssembly.CustomEnumerable")]
+    [TestCase("RefasmerTestAssembly.EnumType")]
+    [TestCase("RefasmerTestAssembly.InternalEnumType")]
     public async Task CheckRefasmedTypeOmitNonApi(string typeName)
     {
         var assemblyPath = await BuildTestAssembly();

--- a/tests/Refasmer.Tests/Printer.cs
+++ b/tests/Refasmer.Tests/Printer.cs
@@ -30,7 +30,7 @@ public static class Printer
             printout.AppendLine($"{indent}fields:");
             foreach (var field in type.Fields)
             {
-                printout.AppendLine($"{indent}- {field.Name}: {field.FieldType}");
+                printout.AppendLine($"{indent}- {GetAccessString(field)} {field.Name}: {field.FieldType}");
             }
         }
 
@@ -82,6 +82,17 @@ public static class Printer
         if (type.IsNestedFamilyOrAssembly) return "protected internal";
         if (type.IsNestedFamilyAndAssembly) return "private protected";
         return "internal";
+    }
+
+    private static string GetAccessString(FieldDefinition field)
+    {
+        if (field.IsPublic) return "public";
+        if (field.IsFamily) return "protected";
+        if (field.IsPrivate) return "private";
+        if (field.IsAssembly) return "internal";
+        if (field.IsFamilyOrAssembly) return "protected internal";
+        if (field.IsFamilyAndAssembly) return "private protected";
+        throw new Exception($"Unknown field accessibility for field {field}.");
     }
 
     private static string GetTypeKindString(TypeDefinition typeDefinition)

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.BlittableGraph.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.BlittableGraph.verified.txt
@@ -1,3 +1,3 @@
 ﻿public struct: RefasmerTestAssembly.BlittableGraph
 fields:
-- <SyntheticNonEmptyStructMarker>: System.Int32
+- private <SyntheticNonEmptyStructMarker>: System.Int32

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.BlittableStructWithPrivateFields.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.BlittableStructWithPrivateFields.verified.txt
@@ -1,3 +1,3 @@
 ﻿public struct: RefasmerTestAssembly.BlittableStructWithPrivateFields
 fields:
-- <SyntheticNonEmptyStructMarker>: System.Int32
+- private <SyntheticNonEmptyStructMarker>: System.Int32

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.EnumType.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.EnumType.verified.txt
@@ -1,8 +1,8 @@
 ﻿public struct: RefasmerTestAssembly.EnumType
   - base type: System.Enum
 fields:
-- value__: System.Int32
-- A: RefasmerTestAssembly.EnumType
-- B: RefasmerTestAssembly.EnumType
-- C: RefasmerTestAssembly.EnumType
-- D: RefasmerTestAssembly.EnumType
+- public value__: System.Int32
+- public A: RefasmerTestAssembly.EnumType
+- public B: RefasmerTestAssembly.EnumType
+- public C: RefasmerTestAssembly.EnumType
+- public D: RefasmerTestAssembly.EnumType

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.EnumType.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.EnumType.verified.txt
@@ -1,0 +1,8 @@
+﻿public struct: RefasmerTestAssembly.EnumType
+  - base type: System.Enum
+fields:
+- value__: System.Int32
+- A: RefasmerTestAssembly.EnumType
+- B: RefasmerTestAssembly.EnumType
+- C: RefasmerTestAssembly.EnumType
+- D: RefasmerTestAssembly.EnumType

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.InternalEnumType.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.InternalEnumType.verified.txt
@@ -1,0 +1,8 @@
+﻿internal struct: RefasmerTestAssembly.InternalEnumType
+  - base type: System.Enum
+fields:
+- value__: System.Int32
+- A: RefasmerTestAssembly.InternalEnumType
+- B: RefasmerTestAssembly.InternalEnumType
+- C: RefasmerTestAssembly.InternalEnumType
+- D: RefasmerTestAssembly.InternalEnumType

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.InternalEnumType.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.InternalEnumType.verified.txt
@@ -1,8 +1,8 @@
 ﻿internal struct: RefasmerTestAssembly.InternalEnumType
   - base type: System.Enum
 fields:
-- value__: System.Int32
-- A: RefasmerTestAssembly.InternalEnumType
-- B: RefasmerTestAssembly.InternalEnumType
-- C: RefasmerTestAssembly.InternalEnumType
-- D: RefasmerTestAssembly.InternalEnumType
+- public value__: System.Int32
+- public A: RefasmerTestAssembly.InternalEnumType
+- public B: RefasmerTestAssembly.InternalEnumType
+- public C: RefasmerTestAssembly.InternalEnumType
+- public D: RefasmerTestAssembly.InternalEnumType

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.NonBlittableGraph.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.NonBlittableGraph.verified.txt
@@ -1,3 +1,3 @@
 ﻿public struct: RefasmerTestAssembly.NonBlittableGraph
 fields:
-- <SyntheticNonEmptyStructMarker>: System.Int32
+- private <SyntheticNonEmptyStructMarker>: System.Int32

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.NonBlittableStructWithPrivateFields.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.NonBlittableStructWithPrivateFields.verified.txt
@@ -1,3 +1,3 @@
 ﻿public struct: RefasmerTestAssembly.NonBlittableStructWithPrivateFields
 fields:
-- <SyntheticNonEmptyStructMarker>: System.Int32
+- private <SyntheticNonEmptyStructMarker>: System.Int32

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.NonEmptyStructWithStaticMember.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.NonEmptyStructWithStaticMember.verified.txt
@@ -1,3 +1,3 @@
 ﻿public struct: RefasmerTestAssembly.NonEmptyStructWithStaticMember
 fields:
-- <SyntheticNonEmptyStructMarker>: System.Int32
+- private <SyntheticNonEmptyStructMarker>: System.Int32

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.PublicClassWithPrivateFields.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.PublicClassWithPrivateFields.verified.txt
@@ -1,5 +1,5 @@
 ﻿public class: RefasmerTestAssembly.PublicClassWithPrivateFields
 fields:
-- PublicInt: System.Int32
+- public PublicInt: System.Int32
 methods:
 - .ctor(): System.Void:

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.PublicStructWithPrivateFields.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.PublicStructWithPrivateFields.verified.txt
@@ -1,3 +1,3 @@
 ﻿public struct: RefasmerTestAssembly.PublicStructWithPrivateFields
 fields:
-- PublicInt: System.Int32
+- public PublicInt: System.Int32

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.StructWithNestedPrivateTypes.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.StructWithNestedPrivateTypes.verified.txt
@@ -1,7 +1,7 @@
 ﻿public struct: RefasmerTestAssembly.StructWithNestedPrivateTypes
 fields:
-- <SyntheticNonEmptyStructMarker>: System.Int32
+- private <SyntheticNonEmptyStructMarker>: System.Int32
 types:
   internal struct: RefasmerTestAssembly.StructWithNestedPrivateTypes/UnusedPublicStruct
   fields:
-  - <SyntheticNonEmptyStructMarker>: System.Int32
+  - private <SyntheticNonEmptyStructMarker>: System.Int32

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.BlittableGraph.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.BlittableGraph.verified.txt
@@ -1,11 +1,11 @@
 ﻿public struct: RefasmerTestAssembly.BlittableGraph
 fields:
-- x: RefasmerTestAssembly.BlittableGraph/BlittableType
+- private x: RefasmerTestAssembly.BlittableGraph/BlittableType
 types:
   private struct: RefasmerTestAssembly.BlittableGraph/BlittableType
   fields:
-  - x: RefasmerTestAssembly.BlittableGraph/BlittableType/BlittableType2
+  - private x: RefasmerTestAssembly.BlittableGraph/BlittableType/BlittableType2
   types:
     private struct: RefasmerTestAssembly.BlittableGraph/BlittableType/BlittableType2
     fields:
-    - x: System.Int64
+    - private x: System.Int64

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.BlittableStructWithPrivateFields.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.BlittableStructWithPrivateFields.verified.txt
@@ -1,5 +1,5 @@
 ﻿public struct: RefasmerTestAssembly.BlittableStructWithPrivateFields
 fields:
-- x: System.Int64
-- y: System.Int64
-- z: System.Int64
+- private x: System.Int64
+- private y: System.Int64
+- private z: System.Int64

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.EnumType.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.EnumType.verified.txt
@@ -1,8 +1,8 @@
 ﻿public struct: RefasmerTestAssembly.EnumType
   - base type: System.Enum
 fields:
-- value__: System.Int32
-- A: RefasmerTestAssembly.EnumType
-- B: RefasmerTestAssembly.EnumType
-- C: RefasmerTestAssembly.EnumType
-- D: RefasmerTestAssembly.EnumType
+- public value__: System.Int32
+- public A: RefasmerTestAssembly.EnumType
+- public B: RefasmerTestAssembly.EnumType
+- public C: RefasmerTestAssembly.EnumType
+- public D: RefasmerTestAssembly.EnumType

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.EnumType.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.EnumType.verified.txt
@@ -1,0 +1,8 @@
+﻿public struct: RefasmerTestAssembly.EnumType
+  - base type: System.Enum
+fields:
+- value__: System.Int32
+- A: RefasmerTestAssembly.EnumType
+- B: RefasmerTestAssembly.EnumType
+- C: RefasmerTestAssembly.EnumType
+- D: RefasmerTestAssembly.EnumType

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.InternalEnumType.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.InternalEnumType.verified.txt
@@ -1,0 +1,8 @@
+﻿internal struct: RefasmerTestAssembly.InternalEnumType
+  - base type: System.Enum
+fields:
+- value__: System.Int32
+- A: RefasmerTestAssembly.InternalEnumType
+- B: RefasmerTestAssembly.InternalEnumType
+- C: RefasmerTestAssembly.InternalEnumType
+- D: RefasmerTestAssembly.InternalEnumType

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.InternalEnumType.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.InternalEnumType.verified.txt
@@ -1,8 +1,8 @@
 ﻿internal struct: RefasmerTestAssembly.InternalEnumType
   - base type: System.Enum
 fields:
-- value__: System.Int32
-- A: RefasmerTestAssembly.InternalEnumType
-- B: RefasmerTestAssembly.InternalEnumType
-- C: RefasmerTestAssembly.InternalEnumType
-- D: RefasmerTestAssembly.InternalEnumType
+- public value__: System.Int32
+- public A: RefasmerTestAssembly.InternalEnumType
+- public B: RefasmerTestAssembly.InternalEnumType
+- public C: RefasmerTestAssembly.InternalEnumType
+- public D: RefasmerTestAssembly.InternalEnumType

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.NonBlittableGraph.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.NonBlittableGraph.verified.txt
@@ -1,11 +1,11 @@
 ﻿public struct: RefasmerTestAssembly.NonBlittableGraph
 fields:
-- x: RefasmerTestAssembly.NonBlittableGraph/DubiouslyBlittableType
+- private x: RefasmerTestAssembly.NonBlittableGraph/DubiouslyBlittableType
 types:
   private struct: RefasmerTestAssembly.NonBlittableGraph/DubiouslyBlittableType
   fields:
-  - x: RefasmerTestAssembly.NonBlittableGraph/DubiouslyBlittableType/NonBlittableType
+  - private x: RefasmerTestAssembly.NonBlittableGraph/DubiouslyBlittableType/NonBlittableType
   types:
     private struct: RefasmerTestAssembly.NonBlittableGraph/DubiouslyBlittableType/NonBlittableType
     fields:
-    - x: System.String
+    - private x: System.String

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.NonBlittableStructWithPrivateFields.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.NonBlittableStructWithPrivateFields.verified.txt
@@ -1,4 +1,4 @@
 ﻿public struct: RefasmerTestAssembly.NonBlittableStructWithPrivateFields
 fields:
-- x: System.String
-- y: System.Int64
+- private x: System.String
+- private y: System.Int64

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.PublicClassWithPrivateFields.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.PublicClassWithPrivateFields.verified.txt
@@ -1,5 +1,5 @@
 ﻿public class: RefasmerTestAssembly.PublicClassWithPrivateFields
 fields:
-- PublicInt: System.Int32
+- public PublicInt: System.Int32
 methods:
 - .ctor(): System.Void:

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.PublicStructWithPrivateFields.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.PublicStructWithPrivateFields.verified.txt
@@ -1,5 +1,5 @@
 ﻿public struct: RefasmerTestAssembly.PublicStructWithPrivateFields
 fields:
-- PrivateInt: System.Int32
-- PrivateInt2: System.Int32
-- PublicInt: System.Int32
+- private PrivateInt: System.Int32
+- private PrivateInt2: System.Int32
+- public PublicInt: System.Int32

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.StructWithNestedPrivateTypes.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedType_typeName=RefasmerTestAssembly.StructWithNestedPrivateTypes.verified.txt
@@ -1,13 +1,13 @@
 ﻿public struct: RefasmerTestAssembly.StructWithNestedPrivateTypes
 fields:
-- PrivateField: RefasmerTestAssembly.StructWithNestedPrivateTypes/NestedPrivateStruct
+- private PrivateField: RefasmerTestAssembly.StructWithNestedPrivateTypes/NestedPrivateStruct
 types:
   private struct: RefasmerTestAssembly.StructWithNestedPrivateTypes/NestedPrivateStruct
   fields:
-  - Field: System.Int32
+  - private Field: System.Int32
   private struct: RefasmerTestAssembly.StructWithNestedPrivateTypes/UnusedPrivateStruct
   fields:
-  - Field: System.Int32
+  - private Field: System.Int32
   internal struct: RefasmerTestAssembly.StructWithNestedPrivateTypes/UnusedPublicStruct
   fields:
-  - Field: System.Int32
+  - private Field: System.Int32

--- a/tests/RefasmerTestAssembly/EnumTypes.cs
+++ b/tests/RefasmerTestAssembly/EnumTypes.cs
@@ -1,0 +1,29 @@
+using RefasmerTestAssembly;
+
+namespace RefasmerTestAssembly
+{
+    public enum EnumType
+    {
+        A = 0,
+        B = 1,
+        C = 4,
+        D = 8
+    }
+
+    internal enum InternalEnumType
+    {
+        A = 0,
+        B = 1,
+        C = 4,
+        D = 8
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#pragma warning disable CS9113 // Parameter is unread.
+    // This type is needed to pin the internal enum, so that it's always imported. This mimics relation between an enum
+    // DynamicallyAccessedMemberTypes and DynamicallyAccessedMembersAttribute.
+    internal class MySomethingAttribute(InternalEnumType value) : Attribute;
+#pragma warning restore CS9113 // Parameter is unread.
+}


### PR DESCRIPTION
This PR prevents us from omitting any members of enum types.

Closes #45.