### PR TITLE
fix --contiue flag on UnknownTypeInSignature exception

### DIFF
--- a/src/RefasmerExe/Program.cs
+++ b/src/RefasmerExe/Program.cs
@@ -209,7 +209,7 @@ public static class Program
                                 throw new ArgumentOutOfRangeException();
                         }
                     }
-                    catch (InvalidOperationException e)
+                    catch (Exception e)
                     {
                         _logger.Error?.Invoke(e.Message);
                         if (continueOnErrors)


### PR DESCRIPTION
The `--continue` flag does not work for me. 'UnknownTypeInSignature' was not caught (and possibly others as well)

```
  [dllname.dll] PE image does not have metadata.
 JetBrains.Refasmer.MetadataImporter+UnknownTypeInSignature: Unknown type in signature: {TypeDef[135]: System.Data.Entity.Edm.Db::DbDatabaseMetadata}
   at JetBrains.Refasmer.MetadataImporter.AcceptTypeSignature[T](BlobReader& blobReader, ISignatureVisitor`1 visitor) in /mnt/agent/work/810daf81501891b9/src/Refasmer/Importer/SignatureImport.cs:line 208
   at JetBrains.Refasmer.MetadataImporter.AcceptSignatureWithHeader[T](BlobHandle srcHandle, ISignatureVisitor`1 visitor) in /mnt/agent/work/810daf81501891b9/src/Refasmer/Importer/SignatureImport.cs:line 86
   at JetBrains.Refasmer.MetadataImporter.<Import>b__109_0(MemberReference src) in /mnt/agent/work/810daf81501891b9/src/Refasmer/Importer/SimpleImports.cs:line 78
   at JetBrains.Refasmer.MetadataImporter.Import(MemberReferenceHandle srcHandle) in /mnt/agent/work/810daf81501891b9/src/Refasmer/Importer/SimpleImports.cs:line 77
   at JetBrains.Refasmer.MetadataImporter.Import(EntityHandle srcHandle) in /mnt/agent/work/810daf81501891b9/src/Refasmer/Importer/SimpleImports.cs:line 159
   at JetBrains.Refasmer.MetadataImporter.ImportEntity[TEntity,THandle](THandle srcHandle, IDictionary`2 cache, Func`2 getEntity, Func`2 import, Func`2 toString, Func`2 isNil) in /mnt/agent/work/810daf81501891b9/src/Refasmer/Importer/SimpleImports.cs:line 89
   at JetBrains.Refasmer.MetadataImporter.ImportTypeDefinitionAccessories(TypeDefinitionHandle srcHandle, TypeDefinitionHandle dstHandle) in /mnt/agent/work/810daf81501891b9/src/Refasmer/Importer/ImportLogic.cs:line 177
   at JetBrains.Refasmer.MetadataImporter.Import() in /mnt/agent/work/810daf81501891b9/src/Refasmer/Importer/ImportLogic.cs:line 508
   at JetBrains.Refasmer.MetadataImporter.MakeRefasm(MetadataReader metaReader, PEReader peReader, LoggerBase logger, IImportFilter filter, Nullable`1 omitNonApiMembers, Boolean makeMock, Boolean omitReferenceAssemblyAttr) in /mnt/agent/work/810daf81501891b9/src/Refasmer/Importer/MetadataImporter.cs:line 95
   at JetBrains.Refasmer.Program.MakeRefasm(ValueTuple`2 input) in /mnt/agent/work/810daf81501891b9/src/RefasmerExe/Program.cs:line 287
   at JetBrains.Refasmer.Program.Main(String[] args) in /mnt/agent/work/810daf81501891b9/src/RefasmerExe/Program.cs:line 203
```