### PR TITLE
Skip explicit implementations of generic methods of internal interfaces

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,4 @@
+# Claude code
+.claude/
+
 *.dll

--- a/src/Refasmer/Importer/ImportLogic.cs
+++ b/src/Refasmer/Importer/ImportLogic.cs
@@ -178,9 +178,17 @@ public partial class MetadataImporter
                 srcImpl =>
                 {
                     var body = Import(srcImpl.MethodBody);
+
+                    // If the method body wasn't imported (e.g., private explicit interface implementation),
+                    // skip importing the declaration. For generic interfaces, the declaration is a
+                    // MemberReference whose import triggers signature processing. If the signature contains
+                    // internal types that weren't preserved, this would throw UnknownTypeInSignature.
+                    // See: https://github.com/JetBrains/Refasmer/issues/54
+                    if (body.IsNil)
+                        return default;
                     var decl = Import(srcImpl.MethodDeclaration);
 
-                    return body.IsNil || decl.IsNil
+                    return decl.IsNil
                         ? default
                         : _builder.AddMethodImplementation(dstHandle, body, decl);
                 },

--- a/src/Refasmer/Importer/ImportLogic.cs
+++ b/src/Refasmer/Importer/ImportLogic.cs
@@ -184,6 +184,10 @@ public partial class MetadataImporter
                     // MemberReference whose import triggers signature processing. If the signature contains
                     // internal types that weren't preserved, this would throw UnknownTypeInSignature.
                     // See: https://github.com/JetBrains/Refasmer/issues/54
+                    //
+                    // Note: a non-generic interface method implementation is not a MemberReference, but a
+                    // MethodDefinition which doesn't trigger signature processing (should be already in the method
+                    // definition cache).
                     if (body.IsNil)
                         return default;
                     var decl = Import(srcImpl.MethodDeclaration);

--- a/tests/Refasmer.Tests/ExitCodeTests.cs
+++ b/tests/Refasmer.Tests/ExitCodeTests.cs
@@ -20,10 +20,13 @@ public class ExitCodeTests : IntegrationTestBase
         var outputPath = Path.GetTempFileName();
         using var collector = CollectConsoleOutput();
         var exitCode = ExecuteRefasmAndGetExitCode(assemblyPath, outputPath, additionalArgs);
+        if (exitCode != expectedCode)
+        {
+            await TestContext.Out.WriteLineAsync($"StdOut:\n{collector.StdOut}\nStdErr: {collector.StdErr}");
+        }
         Assert.That(
             exitCode,
             Is.EqualTo(expectedCode),
-            $"Refasmer returned exit code {exitCode}, while {expectedCode} was expected." +
-            $" StdOut:\n{collector.StdOut}\nStdErr: {collector.StdErr}");
+            $"Refasmer returned exit code {exitCode}, while {expectedCode} was expected.");
     }
 }

--- a/tests/Refasmer.Tests/IntegrationTestBase.cs
+++ b/tests/Refasmer.Tests/IntegrationTestBase.cs
@@ -16,10 +16,15 @@ public abstract class IntegrationTestBase
         Console.WriteLine($"Building project {testProject}…");
         var result = await Command.Run("dotnet", "build", testProject, "--configuration", "Release").Task;
 
+        if (result.ExitCode != 0)
+        {
+            await TestContext.Out.WriteLineAsync($"StdOut:\n{result.StandardOutput}\nStdErr: {result.StandardError}");
+        }
+
         Assert.That(
             result.ExitCode,
             Is.EqualTo(0),
-            $"Failed to build test assembly, exit code {result.ExitCode}. StdOut:\n{result.StandardOutput}\nStdErr: {result.StandardError}");
+            $"Failed to build test assembly, exit code {result.ExitCode}.");
 
         return Path.Combine(
             root,
@@ -67,10 +72,11 @@ public abstract class IntegrationTestBase
         var options = new[]{ "--omit-non-api-members", omitNonApiMembers.ToString(CultureInfo.InvariantCulture) };
         using var collector = CollectConsoleOutput();
         var exitCode = ExecuteRefasmAndGetExitCode(assemblyPath, outputPath, options);
-        Assert.That(
-            exitCode,
-            Is.EqualTo(0),
-            $"Refasmer returned exit code {exitCode}. StdOut:\n{collector.StdOut}\nStdErr: {collector.StdErr}");
+        if (exitCode != 0)
+        {
+            TestContext.Out.WriteLine($"Refasmer returned exit code {exitCode}. StdOut:\n{collector.StdOut}\nStdErr: {collector.StdErr}");
+        }
+        Assert.That(exitCode, Is.EqualTo(0));
 
         return outputPath;
     }

--- a/tests/Refasmer.Tests/IntegrationTests.cs
+++ b/tests/Refasmer.Tests/IntegrationTests.cs
@@ -32,7 +32,7 @@ public class IntegrationTests : IntegrationTestBase
     [TestCase("RefasmerTestAssembly.CustomEnumerable")]
     [TestCase("RefasmerTestAssembly.EnumType")]
     [TestCase("RefasmerTestAssembly.InternalEnumType")]
-    [TestCase("RefasmerTestAssembly.InternalInterfaceImplBug")]
+    [TestCase("RefasmerTestAssembly.ExplicitImplOfInternalInterface")]
     public async Task CheckRefasmedTypeOmitNonApi(string typeName)
     {
         var assemblyPath = await BuildTestAssembly();

--- a/tests/Refasmer.Tests/IntegrationTests.cs
+++ b/tests/Refasmer.Tests/IntegrationTests.cs
@@ -32,6 +32,7 @@ public class IntegrationTests : IntegrationTestBase
     [TestCase("RefasmerTestAssembly.CustomEnumerable")]
     [TestCase("RefasmerTestAssembly.EnumType")]
     [TestCase("RefasmerTestAssembly.InternalEnumType")]
+    [TestCase("RefasmerTestAssembly.InternalInterfaceImplBug")]
     public async Task CheckRefasmedTypeOmitNonApi(string typeName)
     {
         var assemblyPath = await BuildTestAssembly();

--- a/tests/Refasmer.Tests/IntegrationTests.cs
+++ b/tests/Refasmer.Tests/IntegrationTests.cs
@@ -32,7 +32,6 @@ public class IntegrationTests : IntegrationTestBase
     [TestCase("RefasmerTestAssembly.CustomEnumerable")]
     [TestCase("RefasmerTestAssembly.EnumType")]
     [TestCase("RefasmerTestAssembly.InternalEnumType")]
-    [TestCase("RefasmerTestAssembly.ExplicitImplOfInternalInterface")]
     public async Task CheckRefasmedTypeOmitNonApi(string typeName)
     {
         var assemblyPath = await BuildTestAssembly();
@@ -58,6 +57,7 @@ public class IntegrationTests : IntegrationTestBase
     [TestCase("PublicClassImplementingInternal", "IInterface1ToBeMarkedInternal")]
     [TestCase("PublicClassWithInternalInterfaceImpl", "Class3ToBeMarkedInternal,IInterface2ToBeMarkedInternal`1")]
     [TestCase("PublicClassWithInternalTypeInExplicitImpl", "IInterface3")]
+    [TestCase("ExplicitImplOfInternalInterface", "IInternalInterface`1")]
     public async Task InternalTypeInPublicApi(string mainClassName, string auxiliaryClassNames)
     {
         var assemblyPath = await BuildTestAssemblyWithInternalTypeInPublicApi();

--- a/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.ExplicitImplOfInternalInterface.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.CheckRefasmedTypeOmitNonApi_typeName=RefasmerTestAssembly.ExplicitImplOfInternalInterface.verified.txt
@@ -1,0 +1,4 @@
+﻿public class: RefasmerTestAssembly.ExplicitImplOfInternalInterface
+  - interface impl: RefasmerTestAssembly.IInternalInterface`1<System.String>
+methods:
+- .ctor(): System.Void:

--- a/tests/Refasmer.Tests/data/IntegrationTests.InternalTypeInPublicApi_mainClassName=ExplicitImplOfInternalInterface.verified.txt
+++ b/tests/Refasmer.Tests/data/IntegrationTests.InternalTypeInPublicApi_mainClassName=ExplicitImplOfInternalInterface.verified.txt
@@ -2,3 +2,4 @@
   - interface impl: RefasmerTestAssembly.IInternalInterface`1<System.String>
 methods:
 - .ctor(): System.Void:
+internal interface: RefasmerTestAssembly.IInternalInterface`1

--- a/tests/RefasmerTestAssembly/InternalInteraceImplBug.cs
+++ b/tests/RefasmerTestAssembly/InternalInteraceImplBug.cs
@@ -1,0 +1,15 @@
+﻿namespace RefasmerTestAssembly;
+
+public class Class1 : IInternalInterace<string>
+{
+    void IInternalInterace<string>.Method(string x, Internal2 y)
+    {
+    }
+}
+
+internal class Internal2{}
+
+internal interface IInternalInterace<T>
+{
+    void Method(T x, Internal2 y);
+}

--- a/tests/RefasmerTestAssembly/InternalInteraceImplBug.cs
+++ b/tests/RefasmerTestAssembly/InternalInteraceImplBug.cs
@@ -1,15 +1,15 @@
 ﻿namespace RefasmerTestAssembly;
 
-public class Class1 : IInternalInterace<string>
+public class ExplicitImplOfInternalInterface : IInternalInterface<string>
 {
-    void IInternalInterace<string>.Method(string x, Internal2 y)
+    void IInternalInterface<string>.Method(string x, Internal2 y)
     {
     }
 }
 
 internal class Internal2{}
 
-internal interface IInternalInterace<T>
+internal interface IInternalInterface<T>
 {
     void Method(T x, Internal2 y);
 }

--- a/tests/RefasmerTestAssembly/InternalInteraceImplBug.cs
+++ b/tests/RefasmerTestAssembly/InternalInteraceImplBug.cs
@@ -1,5 +1,6 @@
 ﻿namespace RefasmerTestAssembly;
 
+// See #53 and #54.
 public class ExplicitImplOfInternalInterface : IInternalInterface<string>
 {
     void IInternalInterface<string>.Method(string x, Internal2 y)


### PR DESCRIPTION
In the `--omit-non-api-members true` mode, we are preserving the internal interface implementations on public types.

The interface methods themselves are supposed to be skipped, only the fact of implementation is enough.

There was a problem with explicit implementations of generic methods: they have a bit different form in the CLI metadata, and the code that was supposed to skip their import, was still processing their signatures. An attempt to resolve an internal type in the signature of an explicit implementation of an internal interface's generic method (duh) was leading to the titular `UnknownTypeInSignature`.

(Also this includes some QoL fixes for the tests to better push their output so that it's more easily to view in the IDE.)

Closes #54.